### PR TITLE
Add os matrix to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on: [push]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+      
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
I think the linting check should be run on all latest os options.